### PR TITLE
AWS Policy Datasource fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 go.work
 
 .terraform*
+terraform.tfstate

--- a/examples/apex-aws-account/provider.tf
+++ b/examples/apex-aws-account/provider.tf
@@ -14,6 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.50.0"
+    }
+    apex = {
+      source = "dell/apex"
+      version = "1.0.0-beta2"
+    }
+    time = {
+      source = "hashicorp/time"
+      version = "0.11.1"
+    }
+  }
+}
+
 // Example but authenticate with AWS however you would like, more information here: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 provider "aws" {
   shared_config_files      = [var.aws_config_path]

--- a/modules/apex-aws-account/versions.tf
+++ b/modules/apex-aws-account/versions.tf
@@ -19,17 +19,14 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      required_version = ">= 5.50.0"
       version = ">= 5.50.0"
     }
     apex = {
       source = "dell/apex"
-      required_version = ">= 1.0.0-beta"
-      version = ">= 1.0.0-beta"
+      version = ">= 1.0.0-beta2"
     }
     time = {
       source = "hashicorp/time"
-      required_version = ">= 0.11.1"
       version = ">= 0.11.1"
     }
   }


### PR DESCRIPTION
## AWS Apex Policy Datasource Fix

- The AWS Policy datasource now uses a json stringified string instead of a model which we would have to convert into json format. We can now just use this policy string directly. 